### PR TITLE
add tags for filtering step

### DIFF
--- a/extensions/product-offer-pre-purchase/src/index.jsx
+++ b/extensions/product-offer-pre-purchase/src/index.jsx
@@ -149,6 +149,7 @@ function LoadingSkeleton() {
 }
 // [END product-offer-pre-purchase.loading-state]
 
+// [START product-offer-pre-purchase.filter-products]
 function getProductsOnOffer(lines, products) {
   const cartLineProductVariantIds = lines.map((item) => item.merchandise.id);
   return products.filter((product) => {
@@ -158,6 +159,7 @@ function getProductsOnOffer(lines, products) {
     return !isProductVariantInCart;
   });
 }
+// [END product-offer-pre-purchase.filter-products]
 
 // [START product-offer-pre-purchase.offer-ui]
 function ProductOffer({ product, i18n, adding, handleAddToCart, showError }) {


### PR DESCRIPTION
based on darius' feedback, we are highlighting the code to filter the products based on what's in the cart. this doesn't use shopify-specific info but we still want to draw attention to it because it completes the extension